### PR TITLE
[feat][gateway-service] API Gateway 기초 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,10 +22,16 @@ ext {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
-	implementation 'org.springframework.cloud:spring-cloud-starter-gateway-server-webmvc'
+	// Reactive Gateway (WebFlux/Netty 기반) - MVC 버전(gateway-server-webmvc)과 혼용 불가
+	implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
+	// Eureka Client — lb://service-name 방식 라우팅 지원 (LoadBalancer 포함)
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	// Keycloak JWT 서명 검증 (Spring Security Reactive 포함)
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+	// 헬스체크 및 메트릭 엔드포인트
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	// Prometheus
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
@@ -38,4 +44,8 @@ dependencyManagement {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+bootJar {
+	archiveFileName = 'app.jar'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
 
 dependencies {
 	// Reactive Gateway (WebFlux/Netty 기반) - MVC 버전(gateway-server-webmvc)과 혼용 불가
-	implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
+	implementation 'org.springframework.cloud:spring-cloud-starter-gateway-server-webflux'
 	// Eureka Client — lb://service-name 방식 라우팅 지원 (LoadBalancer 포함)
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	// Keycloak JWT 서명 검증 (Spring Security Reactive 포함)

--- a/src/main/java/com/firstticket/gatewayserver/GatewayserverApplication.java
+++ b/src/main/java/com/firstticket/gatewayserver/GatewayserverApplication.java
@@ -2,12 +2,15 @@ package com.firstticket.gatewayserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 
+// Eureka Client 활성화 - Eureka Server에 'gateway-server'로 등록
+// lb://user-service 같은 LoadBalancer URI 사용을 위해 필수
+@EnableDiscoveryClient
 @SpringBootApplication
 public class GatewayserverApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(GatewayserverApplication.class, args);
 	}
-
 }

--- a/src/main/java/com/firstticket/gatewayserver/config/SecurityConfig.java
+++ b/src/main/java/com/firstticket/gatewayserver/config/SecurityConfig.java
@@ -1,0 +1,47 @@
+package com.firstticket.gatewayserver.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+// Gateway는 WebFlux 기반이므로 @EnableWebFluxSecurity 사용
+@Configuration
+@EnableWebFluxSecurity
+public class SecurityConfig {
+
+    // 토큰 검증 없이 접근 가능한 공개 경로 상수 정의 (매직스트링 금지)
+    private static final String[] PUBLIC_PATHS = {
+            "/api/v1/auth/signup",           // 회원가입 - 토큰 불필요
+            "/api/v1/auth/login",            // 로그인 - 토큰 불필요
+            "/api/v1/auth/token/refresh",    // 토큰 재발급 - Refresh Token을 Body로 전달
+            "/actuator/health",              // 헬스체크 - ALB 타겟 그룹 헬스체크용
+            "/actuator/info"                 // 서비스 정보
+    };
+
+    @Bean
+    public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
+        return http
+                // Gateway는 REST API 서버이므로 CSRF비활성화
+                // SameSite 쿠키 전략으로 대체
+                .csrf(ServerHttpSecurity.CsrfSpec::disable)
+
+                .authorizeExchange(exchanges -> exchanges
+                        // 공개 경로는 인증 없이 허용
+                        .pathMatchers(PUBLIC_PATHS).permitAll()
+                        // 그 외 모든 요청은 JWT 필수
+                        .anyExchange().authenticated()
+                )
+
+                // OAuth2 Resource Server 활성화
+                // application.yml의 jwk-set-uri를 사용해 Keycloak 공개키로 JWT 서명 검증
+                // 검증 성공 시 JwtAuthenticationToken이 SecurityContext에 저장됨
+                .oauth2ResourceServer(oauth2 -> oauth2
+                        .jwt(Customizer.withDefaults())
+                )
+
+                .build();
+    }
+}

--- a/src/main/java/com/firstticket/gatewayserver/filter/AuthorizationHeaderFilter.java
+++ b/src/main/java/com/firstticket/gatewayserver/filter/AuthorizationHeaderFilter.java
@@ -1,0 +1,106 @@
+package com.firstticket.gatewayserver.filter;
+
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * JWT 클레임에서 사용자 정보를 추출해 다운스트림 서비스 헤더에 주입하는 GlobalFilter
+ *
+ * 처리 흐름:
+ *   1. Spring Security가 JWT 서명 검증 후 SecurityContext에 JwtAuthenticationToken 저장
+ *   2. 이 필터가 SecurityContext에서 토큰을 꺼내 sub(userId), roles를 추출
+ *   3. X-User-Id, X-User-Role 헤더를 추가한 뒤 다음 필터(라우팅)로 전달
+ *
+ * - 다운스트림 서비스는 이 헤더를 신뢰하며 자체 JWT 재검증을 하지 않음
+ */
+@Component
+public class AuthorizationHeaderFilter implements GlobalFilter, Ordered {
+
+    // 시스템 전용 역할 - Keycloak 기본 realm 역할이므로 다운스트림 헤더에서 제외
+    private static final Set<String> KEYCLOAK_DEFAULT_ROLES = Set.of(
+            "default-roles-first-ticket",
+            "offline_access",
+            "uma_authorization"
+    );
+
+    // Keycloak JWT에서 realm 레벨 역할을 담는 클레임 키
+    private static final String REALM_ACCESS_CLAIM = "realm_access";
+
+    // realm_access 맵 내부에서 역할 목록을 담는 키
+    private static final String ROLES_KEY = "roles";
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        return ReactiveSecurityContextHolder.getContext()
+                // SecurityContext에서 Authentication 꺼내기
+                .map(SecurityContext::getAuthentication)
+                // 익명 사용자(Authentication이 유효한 JwtAuthenticationToken이 아닌 경우) 필터링
+                // 공개 경로(/signup, /login 등)는 JwtAuthenticationToken이 없으므로 switchIfEmpty로 처리
+                .filter(auth -> auth instanceof JwtAuthenticationToken)
+                .cast(JwtAuthenticationToken.class)
+                .flatMap(auth -> {
+                    // JWT의 'sub' 클레임 = Keycloak 내부 사용자 UUID
+                    String userId = auth.getToken().getSubject();
+
+                    // realm_access.roles 에서 애플리케이션 역할만 추출
+                    String roles = extractAppRoles(auth);
+
+                    // 원본 요청을 변경 불가능(Immutable)하므로 mutate()로 새 요청 생성
+                    // 헤더 주입 구간
+                    ServerHttpRequest mutatedRequest = exchange.getRequest().mutate()
+                            .header("X-User-Id", userId)     // 다운스트림 서비스가 사용자 식별에 사용
+                            .header("X-User-Role", roles)    // 다운스트림 서비스가 권한 검증에 사용
+                            .build();
+
+                    // 변경된 요청으로 교환 객체를 다시 빌드해 다음 필터로 전달
+                    return chain.filter(exchange.mutate().request(mutatedRequest).build());
+                })
+                // JWT가 없는 요청(공개 경로) - 헤더 추가 없이 그대로 통과
+                .switchIfEmpty(chain.filter(exchange));
+    }
+
+    /**
+     * Keycloak JWT의 realm_access.roles 에서 앱 역할(CUSTOMER, HOST, ADMIN)만 추출.
+     * 역할이 없거나 클레임이 없으면 빈 문자열 반환.
+     */
+    @SuppressWarnings("unchecked")
+    private String extractAppRoles(JwtAuthenticationToken auth) {
+        // realm_access 클레임은 Map<String, Object> 형태
+        Map<String, Object> realmAccess = auth.getToken().getClaim(REALM_ACCESS_CLAIM);
+
+        if (realmAccess == null || !realmAccess.containsKey(ROLES_KEY)) {
+            return "";  // 역할 클레임 없음 — 빈 문자열로 다운스트림 전달
+        }
+
+        // Keycloak이 역할을 List<String>으로 제공
+        List<String> allRoles = (List<String>) realmAccess.get(ROLES_KEY);
+
+        // Keycloak 기본 역할(offline_access 등)을 제외하고 앱 역할만 남김
+        return allRoles.stream()
+                .filter(role -> !KEYCLOAK_DEFAULT_ROLES.contains(role))
+                .collect(Collectors.joining(","));  // "CUSTOMER,HOST" 형태로 조인
+    }
+
+    /**
+     * GlobalFilter 실행 순서.
+     * Spring Security WebFilter는 -100 근처에서 실행 (SecurityContext 설정 완료)
+     * 해당 필터는 0 에서 실행 -> Security 이후, NettyRoutingFilter(Integer.MAX_VALUE) 이전 보장
+     */
+    @Override
+    public int getOrder() {
+        return 0;
+    }
+}

--- a/src/main/java/com/firstticket/gatewayserver/filter/AuthorizationHeaderFilter.java
+++ b/src/main/java/com/firstticket/gatewayserver/filter/AuthorizationHeaderFilter.java
@@ -42,8 +42,29 @@ public class AuthorizationHeaderFilter implements GlobalFilter, Ordered {
     // realm_access 맵 내부에서 역할 목록을 담는 키
     private static final String ROLES_KEY = "roles";
 
+    // 보안 민감 Header 상수 - 제거·주입 위치에서 동일 문자열 사용 보장
+    private static final String HEADER_USER_ID = "X-User-Id";
+    private static final String HEADER_USER_ROLE = "X-User-Role";
+
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+
+        // 모든 요청에서 보안 헤더를 먼저 제거
+        // 이유: 악의적인 클라이언트가 X-User-Id, X-User-Role을 임의로 심어 보낼 경우
+        // 다운스트림 서비스가 이를 신뢰하는 헤더 스푸핑 공격을 차단하기 위함
+        // 공개 경로(signup, login)에서도 제거 - switchIfEmpty 분기에서 별도 처리 불필요
+        ServerHttpRequest sanitizedRequest = exchange.getRequest().mutate()
+                .headers(headers -> {
+                    headers.remove(HEADER_USER_ID);    // 클라이언트가 위조한 헤더 제거
+                    headers.remove(HEADER_USER_ROLE);  // 클라이언트가 위조한 헤더 제거
+                })
+                .build();
+
+        // 제거된 요청으로 교환 객체 재구성 - 이후 모든 분기에서 이 객체를 기준으로 사용
+        ServerWebExchange sanitizedExchange = exchange.mutate().request(sanitizedRequest).build();
+
+
+
         return ReactiveSecurityContextHolder.getContext()
                 // SecurityContext에서 Authentication 꺼내기
                 .map(SecurityContext::getAuthentication)
@@ -60,16 +81,16 @@ public class AuthorizationHeaderFilter implements GlobalFilter, Ordered {
 
                     // 원본 요청을 변경 불가능(Immutable)하므로 mutate()로 새 요청 생성
                     // 헤더 주입 구간
-                    ServerHttpRequest mutatedRequest = exchange.getRequest().mutate()
-                            .header("X-User-Id", userId)     // 다운스트림 서비스가 사용자 식별에 사용
-                            .header("X-User-Role", roles)    // 다운스트림 서비스가 권한 검증에 사용
+                    ServerHttpRequest mutatedRequest = sanitizedExchange.getRequest().mutate()
+                            .header(HEADER_USER_ID, userId)     // 다운스트림 서비스가 사용자 식별에 사용
+                            .header(HEADER_USER_ROLE, roles)    // 다운스트림 서비스가 권한 검증에 사용
                             .build();
 
                     // 변경된 요청으로 교환 객체를 다시 빌드해 다음 필터로 전달
-                    return chain.filter(exchange.mutate().request(mutatedRequest).build());
+                    return chain.filter(sanitizedExchange.mutate().request(mutatedRequest).build());
                 })
                 // JWT가 없는 요청(공개 경로) - 헤더 추가 없이 그대로 통과
-                .switchIfEmpty(chain.filter(exchange));
+                .switchIfEmpty(chain.filter(sanitizedExchange));
     }
 
     /**
@@ -82,7 +103,7 @@ public class AuthorizationHeaderFilter implements GlobalFilter, Ordered {
         Map<String, Object> realmAccess = auth.getToken().getClaim(REALM_ACCESS_CLAIM);
 
         if (realmAccess == null || !realmAccess.containsKey(ROLES_KEY)) {
-            return "";  // 역할 클레임 없음 — 빈 문자열로 다운스트림 전달
+            return "";  // 역할 클레임 없음 - 빈 문자열로 다운스트림 전달
         }
 
         // Keycloak이 역할을 List<String>으로 제공

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,83 @@
+server:
+  # 로컬 기본 포트 8080
+  # ECS 환경에서는 ALB가 :80 → Task :8080으로 포워딩하므로 변경 불필요
+  port: 8080
+
 spring:
   application:
-    name: gateway-server
+    name: gateway-server   # Eureka에 등록될 서비스 이름
+
+  jackson:
+    # Jackson JSON 직렬화 시 사용할 타임존 설정
+    # 에러 응답 timestamp, LocalDateTime 직렬화 등에 적용됨
+    time-zone: Asia/Seoul
+
+    serialization:
+      # true: 1745123456789 (epoch millis) 형태로 출력
+      # false: "2026-04-23T14:40:19.076+09:00" 문자열 형태로 출력
+      write-dates-as-timestamps: false
+
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          # jwk-set-uri: 애플리케이션 시작 시 즉시 Keycloak에 연결하지 않고
+          # 첫 번째 JWT 검증 요청이 들어올 때 Lazy하게 JWKS를 가져옴 (issuer-uri는 Eager → Keycloak 미기동 시 startup 실패)
+          # 환경변수 KEYCLOAK_JWK_SET_URI 로 오버라이드 가능
+          jwk-set-uri: ${KEYCLOAK_JWK_SET_URI:http://localhost:8180/realms/first-ticket/protocol/openid-connect/certs}
+
+  cloud:
+    gateway:
+      server:
+        webflux:
+          routes:
+            - id: user-service
+              uri: lb://user-service
+              predicates:
+                - Path=/api/v1/auth/**, /api/v1/users/**, /api/v1/admin/users/**, /api/v1/admin/host-requests/**
+
+            - id: program-service
+              uri: lb://program-service
+              predicates:
+                - Path=/api/v1/programs/**
+
+            - id: venue-service
+              uri: lb://venue-service
+              predicates:
+                - Path=/api/v1/venues/**
+
+            - id: booking-service
+              uri: lb://booking-service
+              predicates:
+                - Path=/api/v1/bookings/**, /api/v1/tickets/**, /api/v1/admin/bookings/**
+
+            - id: payment-service
+              uri: lb://payment-service
+              predicates:
+                - Path=/api/v1/payments/**, /api/v1/admin/payments/**
+
+            - id: queue-service
+              uri: lb://queue-service
+              predicates:
+                - Path=/api/v1/queues/**, /api/v1/admin/queues/**
+
+            - id: seat-service
+              uri: lb://seat-service
+              predicates:
+                - Path=/api/v1/seats/**
+
+eureka:
+  client:
+    service-url:
+      defaultZone: ${EUREKA_DEFAULT_ZONE:http://localhost:8761/eureka/}
+    tls:
+      enabled: false   # Spring Cloud 2025.0.x TlsProperties 바인딩 버그 workaround (eureka-server와 동일)
+  instance:
+    prefer-ip-address: true   # ECS Fargate — hostname 대신 컨테이너 IP를 Eureka에 등록
+
+management:
+  endpoints:
+    web:
+      exposure:
+        # 운영 환경: 환경변수로 prometheus 추가 (MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE=health,info,prometheus)
+        include: health, info


### PR DESCRIPTION
## 🌱 설명
- Spring Cloud Gateway 서버 초기 설정
- Keycloak JWT 서명 검증 (OAuth2 Resource Server)
- JWT 클레임에서 사용자 정보 추출 후 X-User-Id, X-User-Role 헤더 주입
- 공개 경로 (signup, login, token/refresh) 인증 제외 설정
- Eureka 연동 lb:// 방식 라우팅 설정 (04-23 기준 6개 서비스)

## 📌 관련 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- 예) close #1


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [x] feat     : 새로운 기능 추가

## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.


## 📚 추가 설명

<html>
<body>
<!--StartFragment--><!-- obsidian --><p><strong>다운스트림 서비스 연동 시 주의사항</strong></p>
<ul>
<li>모든 마이크로서비스는 Gateway가 주입하는 아래 헤더를 신뢰합니다</li>
<li>따라서 자체 JWT 재검증을 하지 않습니다.</li>
</ul>

헤더 | 값 | 출처
-- | -- | --
X-User-Id | Keycloak 사용자 UUID | JWT sub 클레임
X-User-Role | CUSTOMER, HOST, ADMIN 중 해당 역할 | JWT realm_access.roles 클레임 (Keycloak 기본 역할 제외)

<!--EndFragment-->
</body>
</html>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 리액티브(WebFlux) 기반 API 게이트웨이로 마이크로서비스 라우팅 지원
  * 서비스 디스커버리(Eureka) 연동을 통한 자동 로드밸런싱(lb://) 지원
  * 요청에 사용자 식별·권한 헤더를 안전하게 설정하는 보안 필터 추가
  * Prometheus용 메트릭 수집 통합

* **구성 변경**
  * OAuth2 JWT 리소스 서버 및 보안 정책 적용(공개 경로/인증 경로 분리)
  * 게이트웨이 라우팅 규칙 및 관리 엔드포인트 구성
  * 실행 JAR 이름을 app.jar로 고정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->