### PR TITLE
[feat][gateway-server] Access Token Blacklist 조회로 로그아웃 즉시 무효화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@ CONFIG_SERVER_URL=
 # Eureka (Docker 컨테이너명으로 수정)
 EUREKA_SERVER_URL=
 
+# Redis (Docker 컨테이너명으로 수정)
+REDIS_HOST=
+
 # Keycloak JWK Set URI (Docker 컨테이너명으로 설정)
 KEYCLOAK_JWK_SET_URI=
 

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,13 @@ dependencies {
 	implementation 'io.micrometer:micrometer-tracing-bridge-brave'
 	runtimeOnly 'io.zipkin.reporter2:zipkin-reporter-brave'
 
+	// Redis Reactive - WebFlux(non-blocking) 환경에서 Redis 클라이언트 사용
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
+
+	// Lombok — @Slf4j, @RequiredArgsConstructor 애너테이션 사용
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,10 @@ services:
       # spring.security.oauth2.resourceserver.jwt.jwk-set-uri 자동 매핑
       SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI: ${KEYCLOAK_JWK_SET_URI}
 
+      # Redis 연결 - Config Server dev 설정(localhost)을 컨테이너 내부 주소로 오버라이드
+      # spring.data.redis.host 자동 매핑
+      SPRING_DATA_REDIS_HOST: ${REDIS_HOST:-first-ticket-redis}
+
     # actuator/health 엔드포인트로 컨테이너 상태 확인
     # start_period: Spring Boot 기동 시간 확보 (Config Server 연결 포함)
     healthcheck:

--- a/src/main/java/com/firstticket/gatewayserver/filter/AuthorizationHeaderFilter.java
+++ b/src/main/java/com/firstticket/gatewayserver/filter/AuthorizationHeaderFilter.java
@@ -1,9 +1,15 @@
 package com.firstticket.gatewayserver.filter;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.core.Ordered;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
@@ -20,108 +26,157 @@ import java.util.stream.Collectors;
  * JWT 클레임에서 사용자 정보를 추출해 다운스트림 서비스 헤더에 주입하는 GlobalFilter
  *
  * 처리 흐름:
- *   1. Spring Security가 JWT 서명 검증 후 SecurityContext에 JwtAuthenticationToken 저장
- *   2. 이 필터가 SecurityContext에서 토큰을 꺼내 sub(userId), roles를 추출
- *   3. X-User-Id, X-User-Role 헤더를 추가한 뒤 다음 필터(라우팅)로 전달
+ *   1. 보안 헤더 위조 방지 — 모든 인바운드 보안 헤더를 먼저 제거 (스푸핑 차단)
+ *   2. SecurityContext에서 검증 완료된 JwtAuthenticationToken 추출
+ *   3. Redis blacklist 조회 — jti 등록 여부 확인, 등록 시 401 반환
+ *   4. sub, roles, jti, exp를 다운스트림 헤더에 주입하고 전달
+ *   5. JWT가 없는 공개 경로는 헤더 추가 없이 통과
  *
- * - 다운스트림 서비스는 이 헤더를 신뢰하며 자체 JWT 재검증을 하지 않음
+ * blacklist 설계:
+ *   - user-service logout() → Redis SET blacklist:{jti} "1" EX {잔여TTL}
+ *   - 이 필터   → Redis EXISTS blacklist:{jti} 조회
+ *   - Redis 장애 시 fail-open (WARN 로그 + 통과) — 가용성 > 즉시 무효화
  */
+@Slf4j
 @Component
+@RequiredArgsConstructor
 public class AuthorizationHeaderFilter implements GlobalFilter, Ordered {
 
-    // 시스템 전용 역할 - Keycloak 기본 realm 역할이므로 다운스트림 헤더에서 제외
+    // ReactiveStringRedisTemplate - WebFlux non-blocking Redis 클라이언트
+    // StringRedisTemplate(MVC 동기)와 달리 Mono를 반환하여 리액티브 체인에서 사용 가능
+    private final ReactiveStringRedisTemplate redisTemplate;
+
+    // Keycloak 기본 realm 역할 - 다운스트림에 전달할 필요 없으므로 제외
     private static final Set<String> KEYCLOAK_DEFAULT_ROLES = Set.of(
-            "default-roles-first-ticket",
-            "offline_access",
-            "uma_authorization"
+        "default-roles-first-ticket",
+        "offline_access",
+        "uma_authorization"
     );
 
-    // Keycloak JWT에서 realm 레벨 역할을 담는 클레임 키
     private static final String REALM_ACCESS_CLAIM = "realm_access";
+    private static final String ROLES_KEY          = "roles";
 
-    // realm_access 맵 내부에서 역할 목록을 담는 키
-    private static final String ROLES_KEY = "roles";
+    // 보안 헤더 상수 - 제거·주입 위치에서 동일 문자열 사용 보장
+    private static final String HEADER_USER_ID   = "X-User-Id";    // Keycloak sub (UUID)
+    private static final String HEADER_USER_ROLE = "X-User-Role";  // 앱 역할 (CUSTOMER,HOST...)
+    private static final String HEADER_JTI       = "X-Jti";        // JWT ID - blacklist key
+    private static final String HEADER_TOKEN_EXP = "X-Token-Exp";  // JWT exp (epoch 초) - TTL 계산용
 
-    // 보안 민감 Header 상수 - 제거·주입 위치에서 동일 문자열 사용 보장
-    private static final String HEADER_USER_ID = "X-User-Id";
-    private static final String HEADER_USER_ROLE = "X-User-Role";
+    // user-service AccessTokenBlacklistImpl의 key prefix와 반드시 일치해야 함
+    private static final String BLACKLIST_KEY_PREFIX = "blacklist:";
 
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
 
-        // 모든 요청에서 보안 헤더를 먼저 제거
-        // 이유: 악의적인 클라이언트가 X-User-Id, X-User-Role을 임의로 심어 보낼 경우
-        // 다운스트림 서비스가 이를 신뢰하는 헤더 스푸핑 공격을 차단하기 위함
-        // 공개 경로(signup, login)에서도 제거 - switchIfEmpty 분기에서 별도 처리 불필요
+        // 1. 인바운드 보안 헤더 전량 제거
+        // 클라이언트가 X-User-Id, X-Jti 등을 임의 주입하는 헤더 스푸핑 공격을 차단하기 위함
         ServerHttpRequest sanitizedRequest = exchange.getRequest().mutate()
-                .headers(headers -> {
-                    headers.remove(HEADER_USER_ID);    // 클라이언트가 위조한 헤더 제거
-                    headers.remove(HEADER_USER_ROLE);  // 클라이언트가 위조한 헤더 제거
-                })
-                .build();
+            .headers(headers -> {
+                headers.remove(HEADER_USER_ID);
+                headers.remove(HEADER_USER_ROLE);
+                headers.remove(HEADER_JTI);
+                headers.remove(HEADER_TOKEN_EXP);
+            })
+            .build();
 
-        // 제거된 요청으로 교환 객체 재구성 - 이후 모든 분기에서 이 객체를 기준으로 사용
         ServerWebExchange sanitizedExchange = exchange.mutate().request(sanitizedRequest).build();
 
-
-
         return ReactiveSecurityContextHolder.getContext()
-                // SecurityContext에서 Authentication 꺼내기
-                .map(SecurityContext::getAuthentication)
-                // 익명 사용자(Authentication이 유효한 JwtAuthenticationToken이 아닌 경우) 필터링
-                // 공개 경로(/signup, /login 등)는 JwtAuthenticationToken이 없으므로 switchIfEmpty로 처리
-                .filter(auth -> auth instanceof JwtAuthenticationToken)
-                .cast(JwtAuthenticationToken.class)
-                .flatMap(auth -> {
-                    // JWT의 'sub' 클레임 = Keycloak 내부 사용자 UUID
-                    String userId = auth.getToken().getSubject();
+            .map(SecurityContext::getAuthentication)
+            // JwtAuthenticationToken이 아닌 경우(공개 경로)는 switchIfEmpty로 처리
+            .filter(auth -> auth instanceof JwtAuthenticationToken)
+            .cast(JwtAuthenticationToken.class)
+            .flatMap(auth -> {
+                // 2. JWT 클레임 추출
+                String userId = auth.getToken().getSubject(); // sub: Keycloak 사용자 UUID
+                String roles  = extractAppRoles(auth);        // realm_access.roles 필터링
+                String jti    = auth.getToken().getId();      // jti: JWT 고유 식별자
 
-                    // realm_access.roles 에서 애플리케이션 역할만 추출
-                    String roles = extractAppRoles(auth);
+                // expiresAt()이 null이면 0 처리 - 이미 만료로 간주
+                long exp = auth.getToken().getExpiresAt() != null
+                    ? auth.getToken().getExpiresAt().getEpochSecond()
+                    : 0L;
 
-                    // 원본 요청을 변경 불가능(Immutable)하므로 mutate()로 새 요청 생성
-                    // 헤더 주입 구간
-                    ServerHttpRequest mutatedRequest = sanitizedExchange.getRequest().mutate()
-                            .header(HEADER_USER_ID, userId)     // 다운스트림 서비스가 사용자 식별에 사용
-                            .header(HEADER_USER_ROLE, roles)    // 다운스트림 서비스가 권한 검증에 사용
-                            .build();
+                // 3. Redis blacklist 조회 (non-blocking)
+                return redisTemplate.hasKey(BLACKLIST_KEY_PREFIX + jti)
+                    // Redis 장애 처리 — flatMap 이전에 배치하여 Redis 에러만 처리
+                    // onErrorResume이 flatMap 이후에 있으면 setComplete() 에러까지 잡아 500 유발
+                    .onErrorResume(e -> {
+                        log.warn("[blacklist] Redis 조회 실패 - fail-open 적용, jtiPrefix: {}, error: {}",
+                            abbreviated(jti), e.getMessage());
+                        return Mono.just(false); // Redis 장애 시 not-blacklisted로 처리 후 통과
+                    })
+                    .flatMap(isBlacklisted -> {
+                        if (Boolean.TRUE.equals(isBlacklisted)) {
+                            log.warn("[blacklist] 무효화된 토큰 요청 차단 - jtiPrefix: {}",
+                                abbreviated(jti));
+                            ServerHttpResponse response = exchange.getResponse();
+                            response.setStatusCode(HttpStatus.UNAUTHORIZED);
+                            DataBuffer buffer = response.bufferFactory().wrap(new byte[0]);
+                            return response.writeWith(Mono.just(buffer));
+                        }
 
-                    // 변경된 요청으로 교환 객체를 다시 빌드해 다음 필터로 전달
-                    return chain.filter(sanitizedExchange.mutate().request(mutatedRequest).build());
-                })
-                // JWT가 없는 요청(공개 경로) - 헤더 추가 없이 그대로 통과
-                .switchIfEmpty(chain.filter(sanitizedExchange));
+                        // 정상 토큰 — 다운스트림 헤더 주입 후 전달
+                        return chain.filter(
+                            withSecurityHeaders(sanitizedExchange, userId, roles, jti, exp)
+                        );
+                    })
+                    // 5. Redis 장애 시 fail-open 정책
+                    // Access Token TTL이 짧아 비즈니스 임팩트 제한적 → 가용성 우선
+                    .onErrorResume(e -> {
+                        log.warn("[blacklist] Redis 조회 실패 - fail-open 적용, jtiPrefix: {}, error: {}",
+                            abbreviated(jti), e.getMessage());
+                        // Redis 장애에도 서비스 중단 없이 요청 통과
+                        return chain.filter(
+                            withSecurityHeaders(sanitizedExchange, userId, roles, jti, exp)
+                        );
+                    });
+            })
+            // JWT가 없는 요청(signup, login 등 공개 경로) - 헤더 추가 없이 통과
+            .switchIfEmpty(chain.filter(sanitizedExchange));
     }
 
     /**
-     * Keycloak JWT의 realm_access.roles 에서 앱 역할(CUSTOMER, HOST, ADMIN)만 추출.
-     * 역할이 없거나 클레임이 없으면 빈 문자열 반환.
+     * 보안 헤더를 주입한 새 교환 객체 반환
+     * 정상 흐름과 Redis fail-open 두 곳에서 동일하게 사용하므로 메서드로 추출
      */
+    private ServerWebExchange withSecurityHeaders(
+        ServerWebExchange base,
+        String userId, String roles, String jti, long exp
+    ) {
+        ServerHttpRequest mutatedRequest = base.getRequest().mutate()
+            .header(HEADER_USER_ID,   userId)              // 사용자 식별 — 다운스트림 신뢰
+            .header(HEADER_USER_ROLE, roles)               // 권한 정보 — 다운스트림 신뢰
+            .header(HEADER_JTI,       jti)                 // logout 시 blacklist 저장 키
+            .header(HEADER_TOKEN_EXP, String.valueOf(exp)) // Redis TTL 계산용 (epoch 초)
+            .build();
+        return base.mutate().request(mutatedRequest).build();
+    }
+
+    // Keycloak JWT의 realm_access.roles 에서 앱 역할(CUSTOMER, HOST, ADMIN)만 추출
     @SuppressWarnings("unchecked")
     private String extractAppRoles(JwtAuthenticationToken auth) {
-        // realm_access 클레임은 Map<String, Object> 형태
         Map<String, Object> realmAccess = auth.getToken().getClaim(REALM_ACCESS_CLAIM);
 
         if (realmAccess == null || !realmAccess.containsKey(ROLES_KEY)) {
-            return "";  // 역할 클레임 없음 - 빈 문자열로 다운스트림 전달
+            return "";
         }
 
-        // Keycloak이 역할을 List<String>으로 제공
         List<String> allRoles = (List<String>) realmAccess.get(ROLES_KEY);
 
-        // Keycloak 기본 역할(offline_access 등)을 제외하고 앱 역할만 남김
         return allRoles.stream()
-                .filter(role -> !KEYCLOAK_DEFAULT_ROLES.contains(role))
-                .collect(Collectors.joining(","));  // "CUSTOMER,HOST" 형태로 조인
+            .filter(role -> !KEYCLOAK_DEFAULT_ROLES.contains(role))
+            .collect(Collectors.joining(","));
     }
 
-    /**
-     * GlobalFilter 실행 순서.
-     * Spring Security WebFilter는 -100 근처에서 실행 (SecurityContext 설정 완료)
-     * 해당 필터는 0 에서 실행 -> Security 이후, NettyRoutingFilter(Integer.MAX_VALUE) 이전 보장
-     */
+    // 로그용 jti 앞 8자만 출력 - 식별자 원문 노출 방지 (CodeRabbit 마스킹 지침)
+    private String abbreviated(String jti) {
+        if (jti == null || jti.length() <= 8) return "****";
+        return jti.substring(0, 8) + "...";
+    }
+
     @Override
     public int getOrder() {
-        return 0;
+        return 0; // Spring Security WebFilter(-100) 이후, NettyRoutingFilter(MAX_VALUE) 이전 실행
     }
 }


### PR DESCRIPTION
## 🌱 설명

- 로그아웃 후 Access Token을 즉시 무효화하기 위해 Redis Blacklist 조회 기능을 추가합니다.
- `AuthorizationHeaderFilter`가 JWT 서명 검증 이후 Redis에서 `blacklist:{jti}` 존재 여부를 조회하여, 등록된 토큰이면 user-service 도달 없이 401을 반환합니다.
- user-service PR과 함께 배포해야 완전한 기능이 동작합니다.

## 💻 커밋 유형

- [x] feat     : 새로운 기능 추가

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

### 핵심 변경 - `AuthorizationHeaderFilter` 처리 흐름