### PR TITLE
[feat][gateway-server] TracdId 헤더 주입 추가 / 환경별 설정 분리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,12 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
+	// Spring Cache + Caffeine - Spring Cloud LoadBalancer 캐시 백엔드
+	// 미추가 시 default cache 사용 (TTL 35초 고정, 설정 불가)
+	// 추가 시 spring.cloud.loadbalancer.cache.ttl 로 TTL 제어 가능
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'com.github.ben-manes.caffeine:caffeine'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,46 @@
+# gateway-server/docker-compose.prod.yml
+# AWS 배포용 docker-compose - ECR 이미지 pull
+# 필요한 .env 항목:
+#   GATEWAY_IMAGE, CONFIG_SERVER_USERNAME, CONFIG_SERVER_PASSWORD
+#   KEYCLOAK_JWK_SET_URI, REDIS_HOST, EUREKA_DEFAULT_ZONE
+services:
+  gateway-server:
+    image: ${GATEWAY_IMAGE}
+    container_name: first-ticket-gateway
+    ports:
+      - "80:8080"
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+
+      # Eureka
+      EUREKA_SERVER_URL: ${EUREKA_SERVER_URL:-eureka-server}
+      EUREKA_DEFAULT_ZONE: http://${EUREKA_SERVER_URL:-eureka-server}:8761/eureka/
+
+      # Config Server
+      CONFIG_SERVER_USERNAME: ${CONFIG_SERVER_USERNAME}
+      CONFIG_SERVER_PASSWORD: ${CONFIG_SERVER_PASSWORD}
+      SPRING_CLOUD_CONFIG_FAIL_FAST: "true"
+
+      # Keycloak JWK URI — prod.yml의 ${KEYCLOAK_JWK_SET_URI} 참조 대상
+      KEYCLOAK_JWK_SET_URI: ${KEYCLOAK_JWK_SET_URI}
+
+      # Redis
+      REDIS_HOST: ${REDIS_HOST:-first-ticket-redis}
+
+      # Zipkin
+      ZIPKIN_ENDPOINT: ${ZIPKIN_ENDPOINT:-http://zipkin:9411/api/v2/spans}
+
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 90s
+      retries: 3
+    restart: unless-stopped
+    networks:
+      - first-ticket-network
+
+networks:
+  first-ticket-network:
+    external: true
+    name: first-ticket-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,55 +1,38 @@
 # gateway-server/docker-compose.yml
+# 로컬 개발용 - 실행환경 dev
 services:
   gateway-server:
     build:
-      context: .  # Dockerfile이 있는 디렉터리 (gateway-server/)
+      context: .
       dockerfile: Dockerfile
-    # 컨테이너 이름 - docker ps에서 식별자로 사용
     container_name: first-ticket-gateway
-
-    # 호스트 80 -> 컨테이너 8080
-    # Spring Boot는 내부적으로 8080, 외부에는 표준 HTTP 포트 80으로 노출
     ports:
       - "80:8080"
-
     environment:
-      # 활성 프로파일 - .env에 없으면 prod로 기동
-      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-prod}
+      SPRING_PROFILES_ACTIVE: dev
 
-      # Eureka 서버 호스트명 — Docker 네트워크 내에서 컨테이너명으로 통신
-      EUREKA_SERVER_URL: ${EUREKA_SERVER_URL:-eureka-server}
+      EUREKA_SERVER_URL: eureka-server
 
-      # Config Server Basic Auth 인증정보 - .env에서 주입
       CONFIG_SERVER_USERNAME: ${CONFIG_SERVER_USERNAME}
       CONFIG_SERVER_PASSWORD: ${CONFIG_SERVER_PASSWORD}
 
-      # Zipkin 분산 트레이싱 수집 엔드포인트
-      ZIPKIN_ENDPOINT: ${ZIPKIN_ENDPOINT:-http://zipkin:9411/api/v2/spans}
+      SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI: http://first-ticket-keycloak:8080/realms/first-ticket/protocol/openid-connect/certs
 
-      # Keycloak JWK URI - Config Server dev 설정(localhost:8180)을 컨테이너 내부 주소로 오버라이드
-      # spring.security.oauth2.resourceserver.jwt.jwk-set-uri 자동 매핑
-      SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI: ${KEYCLOAK_JWK_SET_URI}
+      SPRING_DATA_REDIS_HOST: first-ticket-redis
 
-      # Redis 연결 - Config Server dev 설정(localhost)을 컨테이너 내부 주소로 오버라이드
-      # spring.data.redis.host 자동 매핑
-      SPRING_DATA_REDIS_HOST: ${REDIS_HOST:-first-ticket-redis}
+      ZIPKIN_ENDPOINT: http://first-ticket-zipkin:9411/api/v2/spans
 
-    # actuator/health 엔드포인트로 컨테이너 상태 확인
-    # start_period: Spring Boot 기동 시간 확보 (Config Server 연결 포함)
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       interval: 30s
       timeout: 5s
-      start_period: 60s
+      start_period: 90s
       retries: 3
-
-    # 비정상 종료 시 자동 재시작 (수동 중지 시에는 재시작 안 함)
     restart: unless-stopped
-
     networks:
       - first-ticket-network
 
 networks:
   first-ticket-network:
-    external: true  # 이 docker-compose가 네트워크를 생성하지 않고, 기존 network 참조
+    external: true
     name: first-ticket-network

--- a/src/main/java/com/firstticket/gatewayserver/GatewayserverApplication.java
+++ b/src/main/java/com/firstticket/gatewayserver/GatewayserverApplication.java
@@ -2,10 +2,12 @@ package com.firstticket.gatewayserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 
 // Eureka Client 활성화 - Eureka Server에 'gateway-server'로 등록
 // lb://user-service 같은 LoadBalancer URI 사용을 위해 필수
+@EnableCaching
 @EnableDiscoveryClient
 @SpringBootApplication
 public class GatewayserverApplication {

--- a/src/main/java/com/firstticket/gatewayserver/filter/TraceIdFilter.java
+++ b/src/main/java/com/firstticket/gatewayserver/filter/TraceIdFilter.java
@@ -1,0 +1,79 @@
+package com.firstticket.gatewayserver.filter;
+
+import io.micrometer.context.ContextSnapshot;
+import io.micrometer.context.ContextSnapshotFactory;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+/**
+ * Zipkin 분산 추적을 위해 traceId를 요청/응답 헤더에 주입하는 GlobalFilter
+ *
+ * currentSpan() null 문제 원인:
+ *   Netty epoll 스레드는 Brave의 ThreadLocal이 자동 전파되지 않음
+ *   → ContextSnapshotFactory로 Reactor Context에 저장된 Brave 컨텍스트를
+ *     현재 스레드의 ThreadLocal로 명시적 복원 후 currentSpan() 호출
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TraceIdFilter implements GlobalFilter, Ordered {
+
+	private final Tracer tracer;
+
+	private final ContextSnapshotFactory snapshotFactory =
+		ContextSnapshotFactory.builder().build();
+
+	private static final String HEADER_TRACE_ID = "X-Trace-Id";
+
+	@Override
+	public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+
+		ServerHttpRequest sanitizedRequest = exchange.getRequest().mutate()
+			.headers(h -> h.remove(HEADER_TRACE_ID))
+			.build();
+		ServerWebExchange sanitizedExchange = exchange.mutate()
+			.request(sanitizedRequest)
+			.build();
+
+		return Mono.deferContextual(contextView -> {
+
+			ContextSnapshot snapshot = snapshotFactory.captureFrom(contextView);
+
+			try (ContextSnapshot.Scope scope = snapshot.setThreadLocals()) {
+
+				Span currentSpan = tracer.currentSpan();
+
+				if (currentSpan == null) {
+					log.debug("[trace] currentSpan is null - X-Trace-Id 주입 생략");
+					return chain.filter(sanitizedExchange);
+				}
+
+				String traceId = currentSpan.context().traceId();
+
+				ServerWebExchange mutatedExchange = sanitizedExchange.mutate()
+					.request(sanitizedExchange.getRequest().mutate()
+						.header(HEADER_TRACE_ID, traceId)
+						.build())
+					.build();
+
+				mutatedExchange.getResponse().getHeaders().set(HEADER_TRACE_ID, traceId);
+
+				return chain.filter(mutatedExchange);
+			}
+		});
+	}
+
+	@Override
+	public int getOrder() {
+		return 1;
+	}
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,7 +11,7 @@ spring:
   profiles:
     # 운영 배포 시: SPRING_PROFILES_ACTIVE=prod → gateway-server-prod.yml 로드
     # 기본값 dev: IntelliJ에서 별도 환경변수 지정 없을 때 로컬 개발 프로파일로 기동
-    active: ${SPRING_PROFILES_ACTIVE}
+    active: ${SPRING_PROFILES_ACTIVE:dev}
 
   config:
     # Config Server 주소 - 환경변수 {CONFIG_SERVER_URI} 로 Override
@@ -28,12 +28,12 @@ spring:
   cloud:
     config:
       # Config Server 연결 실패 시 앱 기동 실패 처리 (운영 권장: true).
-      fail-fast: false  # 로컬 개발 중에는 false, 운영 배포 시 true 로 변경
+      fail-fast: ${SPRING_CLOUD_CONFIG_FAIL_FAST:false}
 
       # Config Server 연결 재시도 설정 (Eureka·Config Server 기동 순서 차이 대비)
       retry:
         initial-interval: 1000  # 첫 재시도 대기 시간 (ms)
-        max-attempts: 5         # 최대 재시도 횟수
+        max-attempts: 6         # 최대 재시도 횟수
         max-interval: 2000      # 재시도 간격 상한 (ms)
       # Config Server Basic Auth 인증정보
       # .env 환경변수로 주입


### PR DESCRIPTION
## 🌱 설명
  - Config Server 설정을 config-repo로 완전 이관하고 dev/prod 프로파일 분리
  - Docker Compose를 로컬 빌드용과 운영 ECR 이미지용으로 분리
  - Caffeine 캐시 적용으로 LoadBalancer 캐시 TTL 명시적 제어
  - TraceIdFilter 구현으로 Zipkin 분산 추적 연결 및 클라이언트 traceId 노출


## 📌 관련 이슈
- close #11 


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [x] feat     : 새로운 기능 추가
- [ ] fix      : 버그 수정 (긴급 핫픽스 포함)
- [ ] refactor : 리팩토링
- [x] chore    : 빌드 설정, 의존성 업데이트 등
- [ ] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [ ] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
  ### Config Server 연동
  - `application.yaml`을 bootstrap 최소 설정으로 축소 (Config Server discovery-first 전환)
  - `config-repo` gateway 설정을 `gateway-server.yml` / `gateway-server-dev.yml` / `gateway-server-prod.yml` 3파일로 분리
  - Zipkin 트레이싱 엔드포인트 추가 (`${ZIPKIN_ENDPOINT}`)
  - `fail-fast`, 프로파일 활성화를 환경변수 기반으로 전환

  ### Docker Compose 환경 분리
  - `docker-compose.yml`: 로컬 개발용 (소스 빌드, dev 프로파일, `first-ticket-network`)
  - `docker-compose.prod.yml`: 운영 배포용 (ECR 이미지, prod 프로파일)
  - `.env`: IntelliJ 직접 실행 기준으로 정리 (미사용 항목 제거, localhost 기반값)

  ### Caffeine 캐시
  - `build.gradle`: `spring-boot-starter-cache`, `caffeine` 의존성 추가
  - `@EnableCaching` 활성화
  - dev 환경 LoadBalancer 캐시 TTL 35초 → 5초, Eureka fetch 주기 30초 → 5초 단축

  ### TraceId 헤더 주입
  - `TraceIdFilter`(GlobalFilter, order=1) 구현
  - 다운스트림 요청 및 응답 헤더에 `X-Trace-Id` 주입
  - 인바운드 `X-Trace-Id` 제거로 클라이언트 헤더 위조 차단
  - Netty epoll 스레드의 Brave ThreadLocal 미전파 이슈 해결
    (`ContextSnapshotFactory`로 Reactor Context → ThreadLocal 복원 후 `currentSpan()` 호출)


<img width="1050" height="857" alt="image" src="https://github.com/user-attachments/assets/6dc9d32e-6225-4000-9e34-c75c7a167a4b" />

<img width="1479" height="639" alt="image" src="https://github.com/user-attachments/assets/150ba008-88c2-4cb7-a65d-a75680d1b4ac" />
