### PR TITLE
[chore][gateway-server] CI/CD ECS 배포 워크플로우 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,127 @@
+# first-ticket / gateway-server CI/CD 통합 워크플로우
+name: CI/CD - Build, Test, and Deploy
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+  push:
+    branches:
+      - main
+      - dev
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: ap-northeast-2
+  ECR_REPOSITORY: first-ticket/gateway-server
+
+jobs:
+
+  # Job 1: 빌드/테스트 (PR·push 모두 실행)
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant execute permission to gradlew
+        run: chmod +x gradlew
+
+      - name: Build & Test
+        run: ./gradlew test bootJar --no-daemon
+
+      - name: Upload test report (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: build/reports/tests/
+          retention-days: 7
+
+  # Job 2: ECR 이미지 푸시 + ECS 배포 (main/dev 브랜치 push시)
+  push-to-ecr:
+    needs: build-and-test
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # OIDC 방식으로 AWS 자격증명 구성 (장기 키 없이 임시 토큰 발급)
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      # ECR 로그인 (registry 주소를 outputs으로 참조)
+      - name: Login to Amazon ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      # linux/amd64 크로스 플랫폼 빌드를 위한 Buildx 설정
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # GitHub Packages 미사용 — --build-arg / --secret 없이 단순 빌드
+      - name: Build, tag, and push image to ECR
+        env:
+          REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker buildx build --platform linux/amd64 \
+            -t $REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
+            -t $REGISTRY/$ECR_REPOSITORY:latest \
+            --push \
+            .
+
+      - name: Show pushed image
+        run: |
+          echo "Pushed: $ECR_REPOSITORY:${{ github.sha }}"
+          echo "Pushed: $ECR_REPOSITORY:latest"
+
+      - name: Download task definition
+        run: |
+          aws ecs describe-task-definition --task-definition gateway-server \
+            --query taskDefinition > task-definition.json
+          
+      - name: Render task definition with new image
+        id: task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: task-definition.json
+          container-name: gateway-server
+          image: ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
+
+      # SPRING_PROFILES_ACTIVE를 prod로 강제 고정
+      - name: Override SPRING_PROFILES_ACTIVE to prod
+        run: |
+          jq '
+            .containerDefinitions[0].environment |= map(
+              if .name == "SPRING_PROFILES_ACTIVE" then .value = "prod" else . end
+            )
+          ' "${{ steps.task-def.outputs.task-definition }}" > task-definition-final.json
+
+      - name: Deploy to ECS
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: task-definition-final.json
+          service: gateway-server-service
+          cluster: first-ticket-cluster
+          wait-for-service-stability: false

--- a/src/test/java/com/firstticket/gatewayserver/GatewayserverApplicationTests.java
+++ b/src/test/java/com/firstticket/gatewayserver/GatewayserverApplicationTests.java
@@ -2,12 +2,22 @@ package com.firstticket.gatewayserver;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
+@TestPropertySource(properties = {
+	"spring.cloud.config.enabled=false",
+	"eureka.client.enabled=false",
+	"spring.data.redis.host=localhost"
+})
 class GatewayserverApplicationTests {
+
+	@MockitoBean
+	ReactiveJwtDecoder jwtDecoder;
 
 	@Test
 	void contextLoads() {
 	}
-
 }


### PR DESCRIPTION


## 🌱 설명

- gateway-server CI/CD 워크플로우에서 ECR에 푸시한 새 이미지가 ECS 배포에 반영되지 않던 버그 수정
- `amazon-ecs-render-task-definition` 스텝을 추가해 task definition의 image URI를 새 커밋 SHA로 갱신
- jq 오버라이드(`SPRING_PROFILES_ACTIVE=prod`) 입력을 render 출력 파일로 변경




## 📌 관련 이슈
- close #14 


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [ ] feat     : 새로운 기능 추가
- [ ] fix      : 버그 수정 (긴급 핫픽스 포함)
- [ ] refactor : 리팩토링
- [x] chore    : 빌드 설정, 의존성 업데이트 등
- [ ] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [ ] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [ ] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?