### PR TITLE
[feat][gateway-server] AuthorizationHeaderFilter blacklist 조회 Caffeine L1 캐시 적용

### DIFF
--- a/src/main/java/com/firstticket/gatewayserver/filter/AuthorizationHeaderFilter.java
+++ b/src/main/java/com/firstticket/gatewayserver/filter/AuthorizationHeaderFilter.java
@@ -1,5 +1,7 @@
 package com.firstticket.gatewayserver.filter;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
@@ -20,22 +22,28 @@ import reactor.core.publisher.Mono;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
  * JWT 클레임에서 사용자 정보를 추출해 다운스트림 서비스 헤더에 주입하는 GlobalFilter
  *
  * 처리 흐름:
- *   1. 보안 헤더 위조 방지 — 모든 인바운드 보안 헤더를 먼저 제거 (스푸핑 차단)
+ *   1. 보안 헤더 위조 방지 - 모든 인바운드 보안 헤더를 먼저 제거 (스푸핑 차단)
  *   2. SecurityContext에서 검증 완료된 JwtAuthenticationToken 추출
- *   3. Redis blacklist 조회 — jti 등록 여부 확인, 등록 시 401 반환
- *   4. sub, roles, jti, exp를 다운스트림 헤더에 주입하고 전달
- *   5. JWT가 없는 공개 경로는 헤더 추가 없이 통과
+ *   3. L1 캐시(Caffeine) 조회 → 히트 시 Redis 미호출
+ *   4. L1 미스 → Redis blacklist 조회 후 결과 L1 캐시 저장
+ *   5. sub, roles, jti, exp를 다운스트림 헤더에 주입하고 전달
+ *   6. JWT가 없는 공개 경로는 헤더 추가 없이 통과
  *
  * blacklist 설계:
  *   - user-service logout() → Redis SET blacklist:{jti} "1" EX {잔여TTL}
- *   - 이 필터   → Redis EXISTS blacklist:{jti} 조회
+ *   - 이 필터   → L1 캐시 → Redis EXISTS blacklist:{jti} (L1 미스 시만)
  *   - Redis 장애 시 fail-open (WARN 로그 + 통과) — 가용성 > 즉시 무효화
+ *
+ * L1 캐시 트레이드오프:
+ *   - TTL 5초: 로그아웃 후 최대 5초간 이전 캐시 결과 사용
+ *   - AT TTL(수 분)에 비해 허용 범위 내이며 Redis 호출 ~99% 감소
  */
 @Slf4j
 @Component
@@ -43,8 +51,15 @@ import java.util.stream.Collectors;
 public class AuthorizationHeaderFilter implements GlobalFilter, Ordered {
 
     // ReactiveStringRedisTemplate - WebFlux non-blocking Redis 클라이언트
-    // StringRedisTemplate(MVC 동기)와 달리 Mono를 반환하여 리액티브 체인에서 사용 가능
     private final ReactiveStringRedisTemplate redisTemplate;
+
+    // blacklist 조회 결과 로컬 캐시 (L1)
+    // TTL 5초: 로그아웃 전파 지연 허용 범위 내에서 Redis 왕복 제거
+    // max 10,000: vuser 70 기준 활성 JTI는 수백 건, 메모리 ~2MB 이내
+    private final Cache<String, Boolean> blacklistLocalCache = Caffeine.newBuilder()
+        .maximumSize(10_000)
+        .expireAfterWrite(5, TimeUnit.SECONDS)
+        .build();
 
     // Keycloak 기본 realm 역할 - 다운스트림에 전달할 필요 없으므로 제외
     private static final Set<String> KEYCLOAK_DEFAULT_ROLES = Set.of(
@@ -56,11 +71,11 @@ public class AuthorizationHeaderFilter implements GlobalFilter, Ordered {
     private static final String REALM_ACCESS_CLAIM = "realm_access";
     private static final String ROLES_KEY          = "roles";
 
-    // 보안 헤더 상수 - 제거·주입 위치에서 동일 문자열 사용 보장
-    private static final String HEADER_USER_ID   = "X-User-Id";    // Keycloak sub (UUID)
-    private static final String HEADER_USER_ROLE = "X-User-Role";  // 앱 역할 (CUSTOMER,HOST...)
-    private static final String HEADER_JTI       = "X-Jti";        // JWT ID - blacklist key
-    private static final String HEADER_TOKEN_EXP = "X-Token-Exp";  // JWT exp (epoch 초) - TTL 계산용
+    // 보안 헤더 상수 — 제거·주입 위치에서 동일 문자열 사용 보장
+    private static final String HEADER_USER_ID   = "X-User-Id";
+    private static final String HEADER_USER_ROLE = "X-User-Role";
+    private static final String HEADER_JTI       = "X-Jti";
+    private static final String HEADER_TOKEN_EXP = "X-Token-Exp";
 
     // user-service AccessTokenBlacklistImpl의 key prefix와 반드시 일치해야 함
     private static final String BLACKLIST_KEY_PREFIX = "blacklist:";
@@ -68,8 +83,7 @@ public class AuthorizationHeaderFilter implements GlobalFilter, Ordered {
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
 
-        // 1. 인바운드 보안 헤더 전량 제거
-        // 클라이언트가 X-User-Id, X-Jti 등을 임의 주입하는 헤더 스푸핑 공격을 차단하기 위함
+        // 1. 인바운드 보안 헤더 전량 제거 - 클라이언트 헤더 스푸핑 차단
         ServerHttpRequest sanitizedRequest = exchange.getRequest().mutate()
             .headers(headers -> {
                 headers.remove(HEADER_USER_ID);
@@ -92,53 +106,71 @@ public class AuthorizationHeaderFilter implements GlobalFilter, Ordered {
                 String roles  = extractAppRoles(auth);        // realm_access.roles 필터링
                 String jti    = auth.getToken().getId();      // jti: JWT 고유 식별자
 
-                // expiresAt()이 null이면 0 처리 - 이미 만료로 간주
+                // expiresAt()이 null이면 0 처리 — 이미 만료로 간주
                 long exp = auth.getToken().getExpiresAt() != null
                     ? auth.getToken().getExpiresAt().getEpochSecond()
                     : 0L;
 
-                // 3. Redis blacklist 조회 (non-blocking)
+                // 3-A. L1 캐시 조회 — Redis 왕복 없이 이전 결과 재사용
+                // getIfPresent: null 반환 시 캐시 미스, Redis로 폴백
+                Boolean cached = blacklistLocalCache.getIfPresent(jti);
+                if (cached != null) {
+                    if (Boolean.TRUE.equals(cached)) {
+                        // 캐시에 이미 blacklisted 기록됨 — 즉시 차단
+                        return rejectBlacklisted(exchange, jti);
+                    }
+                    // 캐시에 정상 기록됨 — Redis 없이 헤더 주입 후 전달
+                    return chain.filter(
+                        withSecurityHeaders(sanitizedExchange, userId, roles, jti, exp)
+                    );
+                }
+
+                // 3-B. L1 캐시 미스 → Redis L2 조회
                 return redisTemplate.hasKey(BLACKLIST_KEY_PREFIX + jti)
-                    // Redis 장애 처리 — flatMap 이전에 배치하여 Redis 에러만 처리
-                    // onErrorResume이 flatMap 이후에 있으면 setComplete() 에러까지 잡아 500 유발
+                    // Redis 장애 처리 — flatMap 이전 배치로 setComplete() 에러 혼입 방지
                     .onErrorResume(e -> {
                         log.warn("[blacklist] Redis 조회 실패 - fail-open 적용, jtiPrefix: {}, error: {}",
                             abbreviated(jti), e.getMessage());
-                        return Mono.just(false); // Redis 장애 시 not-blacklisted로 처리 후 통과
+                        return Mono.just(false); // 장애 시 not-blacklisted로 처리
                     })
                     .flatMap(isBlacklisted -> {
+                        // Redis 조회 결과를 L1 캐시에 저장 — 동일 JTI 재요청은 캐시 히트
+                        blacklistLocalCache.put(jti, isBlacklisted);
                         if (Boolean.TRUE.equals(isBlacklisted)) {
-                            log.warn("[blacklist] 무효화된 토큰 요청 차단 - jtiPrefix: {}",
-                                abbreviated(jti));
-                            ServerHttpResponse response = exchange.getResponse();
-                            response.setStatusCode(HttpStatus.UNAUTHORIZED);
-                            DataBuffer buffer = response.bufferFactory().wrap(new byte[0]);
-                            return response.writeWith(Mono.just(buffer));
+                            return rejectBlacklisted(exchange, jti);
                         }
-
-                        // 정상 토큰 — 다운스트림 헤더 주입 후 전달
                         return chain.filter(
                             withSecurityHeaders(sanitizedExchange, userId, roles, jti, exp)
                         );
                     })
-                    // 5. Redis 장애 시 fail-open 정책
-                    // Access Token TTL이 짧아 비즈니스 임팩트 제한적 → 가용성 우선
+                    // Redis 장애 시 fail-open — 가용성 우선
                     .onErrorResume(e -> {
                         log.warn("[blacklist] Redis 조회 실패 - fail-open 적용, jtiPrefix: {}, error: {}",
                             abbreviated(jti), e.getMessage());
-                        // Redis 장애에도 서비스 중단 없이 요청 통과
                         return chain.filter(
                             withSecurityHeaders(sanitizedExchange, userId, roles, jti, exp)
                         );
                     });
             })
-            // JWT가 없는 요청(signup, login 등 공개 경로) - 헤더 추가 없이 통과
+            // JWT 없는 요청(공개 경로) — 헤더 추가 없이 통과
             .switchIfEmpty(chain.filter(sanitizedExchange));
     }
 
     /**
+     * blacklisted JTI 차단 응답 — 401 반환
+     * L1 캐시 히트와 Redis 조회 두 경로에서 공통 사용
+     */
+    private Mono<Void> rejectBlacklisted(ServerWebExchange exchange, String jti) {
+        log.warn("[blacklist] 무효화된 토큰 요청 차단 - jtiPrefix: {}", abbreviated(jti));
+        ServerHttpResponse response = exchange.getResponse();
+        response.setStatusCode(HttpStatus.UNAUTHORIZED);
+        DataBuffer buffer = response.bufferFactory().wrap(new byte[0]); // 빈 바디로 응답
+        return response.writeWith(Mono.just(buffer));
+    }
+
+    /**
      * 보안 헤더를 주입한 새 교환 객체 반환
-     * 정상 흐름과 Redis fail-open 두 곳에서 동일하게 사용하므로 메서드로 추출
+     * 정상 흐름과 Redis fail-open 두 곳에서 동일하게 사용
      */
     private ServerWebExchange withSecurityHeaders(
         ServerWebExchange base,
@@ -169,7 +201,7 @@ public class AuthorizationHeaderFilter implements GlobalFilter, Ordered {
             .collect(Collectors.joining(","));
     }
 
-    // 로그용 jti 앞 8자만 출력 - 식별자 원문 노출 방지 (CodeRabbit 마스킹 지침)
+    // 로그용 jti 앞 8자만 출력 - 식별자 원문 노출 방지
     private String abbreviated(String jti) {
         if (jti == null || jti.length() <= 8) return "****";
         return jti.substring(0, 8) + "...";
@@ -177,6 +209,6 @@ public class AuthorizationHeaderFilter implements GlobalFilter, Ordered {
 
     @Override
     public int getOrder() {
-        return 0; // Spring Security WebFilter(-100) 이후, NettyRoutingFilter(MAX_VALUE) 이전 실행
+        return 0; // Spring Security WebFilter(-100) 이후, NettyRoutingFilter(MAX_VALUE) 이전
     }
 }


### PR DESCRIPTION


## 🌱 설명
- `AuthorizationHeaderFilter`의 Redis blacklist 조회 앞단에 Caffeine L1 캐시 추가
- 동일 JTI 재요청(5초 이내)은 Redis 왕복 없이 메모리 조회(~100ns)로 처리


## 📌 관련 이슈
- close #18 


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [x] feat     : 새로운 기능 추가
- [ ] fix      : 버그 수정 (긴급 핫픽스 포함)
- [ ] refactor : 리팩토링
- [ ] chore    : 빌드 설정, 의존성 업데이트 등
- [ ] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [ ] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
**개선 배경 (Before 부하테스트 수치)**
- 테스트 조건: vuser 10→70 Ramp-Up, 7분, GET /users/me 85% + POST /auth/login 15%
- vuser=10 MTT: 7ms → vuser=70 MTT: **46ms (535% 증가)**
- 포화 구간: MTT 54ms >> 스파이크 24회
- 원인: 동시 Redis hasKey Mono 적체 → Lettuce 커넥션 풀 압박

**개선 원리**
```
Before: 모든 인증 요청 → Redis hasKey (~1-3ms 네트워크 왕복)
After:  동일 JTI 재요청 → Caffeine.getIfPresent() (~100ns 메모리 조회)
        초당 Redis 호출: ~1,400회 → ~14회 (99% 감소)
```

**캐시 설계**
- `maximumSize(10_000)` / `expireAfterWrite(5s)`
- TTL 트레이드오프: 로그아웃 후 최대 5초 지연 - AT TTL 대비 허용 범위
- 신규 의존성 없음 (기존 Caffeine 의존성 재사용)

**영향 범위**
- 이 변경은 gateway를 통과하는 **모든 서비스의 인증 경로**에 적용됨
- 타 서비스 코드·API 계약 변경 없음
- user-service의 blacklist 쓰기(`SET blacklist:{jti}`) 동작 변경 없음